### PR TITLE
Removed assertion for matching hostnames

### DIFF
--- a/github/Requester.py
+++ b/github/Requester.py
@@ -439,7 +439,6 @@ class Requester:
             url = self.__prefix + url
         else:
             o = six.moves.urllib.parse.urlparse(url)
-            assert o.hostname in [self.__hostname, "uploads.github.com", "status.github.com"], o.hostname
             assert o.path.startswith((self.__prefix, "/api/"))
             assert o.port == self.__port
             url = o.path


### PR DESCRIPTION
Allows us to maintain both a proxy server address for our Github API endpoint. [See issue 1234 on PyGithub](https://github.com/PyGithub/PyGithub/issues/1234) for more context (also shown below)

Hello, I'm having trouble using PyGithub for a Github Enterprise. Our Github Enterprise appliance is private and we have it behind a proxy.

When creating the Github client, I set our base_url to https://git-atlassian.corp.example.com/api/v3. I then try getting the contents of a repo.
```
# Successfully returns a Repository instance
github_repo = client.get_repo('Example/repo_name')
# Returns an Assertion Error, since the repo contents_url is https://git.corp.example.com/, which doesn't match the original base_url hostname
file_contents = github_repo.get_contents('/filename.py')
```
We then get the following AssertionError:

    "traceback": "Traceback (most recent call last):
      File \"/var/task/handlers/lex/lexhandler.py\", line 130, in handler
        resp = self.handle_hook(event)
      File \"/var/task/handlers/lex/codehook.py\", line 62, in handle_hook
        return intent.handle_intent()
      File \"/var/task/handlers/lex/intents/baseintent.py\", line 467, in handle_intent
        ret = self._handle_intent()
      File \"/var/task/handlers/lex/intents/aws_ecs.py\", line 383, in _handle_intent
        for repo in github_repos:
      File \"/opt/python/github/PaginatedList.py\", line 62, in __iter__
        newElements = self._grow()
      File \"/opt/python/github/PaginatedList.py\", line 74, in _grow
        newElements = self._fetchNextPage()
      File \"/opt/python/github/PaginatedList.py\", line 199, in _fetchNextPage
        headers=self.__headers
      File \"/opt/python/github/Requester.py\", line 276, in requestJsonAndCheck
        return self.__check(*self.requestJson(verb, url, parameters, headers, input, self.__customConnection(url)))
      File \"/opt/python/github/Requester.py\", line 336, in requestJson
        return self.__requestEncode(cnx, verb, url, parameters, headers, input, encode)
      File \"/opt/python/github/Requester.py\", line 380, in __requestEncode
        url = self.__makeAbsoluteUrl(url)
      File \"/opt/python/github/Requester.py\", line 450, in __makeAbsoluteUrl
        assert o.hostname in [self.__hostname, \"uplads.github.com\", \"status.github.com\"], o.hostname
        AssertionError: git.corp.example.com
    ",
```
Reference:
- Proxy DNS is git-atlassian.corp.example.com
- GHE DNS is git.corp.example.com